### PR TITLE
Generate just one seed, rather than generating two seeds and then tak…

### DIFF
--- a/site/en/tutorials/images/data_augmentation.ipynb
+++ b/site/en/tutorials/images/data_augmentation.ipynb
@@ -1273,7 +1273,7 @@
       "source": [
         "# Create a wrapper function for updating seeds.\n",
         "def f(x, y):\n",
-        "  seed = rng.make_seeds(2)[0]\n",
+        "  seed = rng.make_seeds(1)[:, 0]\n",
         "  image, label = augment((x, y), seed)\n",
         "  return image, label"
       ]


### PR DESCRIPTION
…ing the first half of each seed.

rng.make_seeds(n) generates a tensor with shape (2,n): each seed is a 2-tuple. The previous code took the first half of each of two seed tuples. Instead, we generate just one 2-tuple.

PiperOrigin-RevId: 606866194